### PR TITLE
[32기 이하영]Add: join modal 레이아웃 구현완성

### DIFF
--- a/src/components/JoinModal/JoinModal.js
+++ b/src/components/JoinModal/JoinModal.js
@@ -1,0 +1,292 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import Button from '../Button/Buttons';
+import { STACK_LIST } from '../Card/cardData';
+
+const JoinModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [stackList, setStackList] = useState([]);
+  const [userInfo, setUserInfo] = useState({
+    git: '',
+    stackes: stackList,
+    position: null,
+    portfolio: null,
+  });
+
+  const { git, stackes, position, portfolio } = userInfo;
+  const navigate = useNavigate();
+
+  const handleStack = id => {
+    if (stackList.includes(id)) {
+      setUserInfo({
+        ...userInfo,
+        stackes: stackList.filter(stack => stack !== id),
+      });
+      setStackList(stackList.filter(stack => stack !== id));
+    } else {
+      setUserInfo({ ...userInfo, stackes: stackList.concat(id) });
+      setStackList(stackList.concat(id));
+    }
+  };
+
+  const choicePortfolio = e => {
+    setUserInfo(e.target.checked);
+  };
+
+  const handleBtn = e => {
+    e.preventDefault();
+    const isRequiredFieldFill =
+      stackes.length > 0 && git.length > 0 && position;
+    if (isRequiredFieldFill) {
+      setIsModalOpen(false);
+      alert('신청 완료 되었습니다 :)');
+      navigate('/mypage');
+      setUserInfo({
+        git: '',
+        stackes: setStackList([]),
+        position: null,
+        portfolio: null,
+      });
+    } else {
+      alert('*필수값 입력해 주세요 :)');
+    }
+  };
+
+  const handleTextChange = e => {
+    const { name, value, checked } = e.target;
+    const isCheckClicked = name.indexOf('check') === -1;
+    setUserInfo(userInfo => {
+      return {
+        ...userInfo,
+        [name]: isCheckClicked ? value : checked,
+      };
+    });
+  };
+
+  const goToDetail = () => {
+    setIsModalOpen(false);
+    navigate('/detail');
+    setUserInfo({
+      git: '',
+      stackes: setStackList([]),
+      position: null,
+      portfolio: null,
+    });
+  };
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+  return (
+    <>
+      <GoToJoin onClick={openModal}>소인 그대와 조인할것이옵니다.</GoToJoin>
+      {isModalOpen && (
+        <Modal>
+          <ModalForm>
+            <ExitBtn type="button" onClick={goToDetail}>
+              ☓
+            </ExitBtn>
+            <ProjectName>
+              <ProjectNameText>프로젝트명 : </ProjectNameText>
+              <ProjectNameText>남은 인원 : </ProjectNameText>
+              <ProjectNameText>필수 스택 : </ProjectNameText>
+            </ProjectName>
+            <CheckBoxWrap>
+              <Title noMargin="noMargin">* Position</Title>
+              <CheckBox>
+                <PositionBtn
+                  type="radio"
+                  id="checkBox"
+                  name="position"
+                  onChange={handleTextChange}
+                  value="frontend"
+                />
+                <Label htmlFor="checkBox">front end</Label>
+              </CheckBox>
+              <CheckBox>
+                <ChoiceBtn
+                  type="radio"
+                  id="choiceBox"
+                  name="position"
+                  onChange={handleTextChange}
+                  value="backend"
+                />
+                <Label htmlFor="choiceBox">back end</Label>
+              </CheckBox>
+            </CheckBoxWrap>
+            <ButtonBox>
+              <Title>* 기술 스택</Title>
+              {STACK_LIST.map(stack => (
+                <Button
+                  key={stack.id}
+                  text={stack.name}
+                  isClicked={stackList.includes(stack.name)}
+                  handleClick={() => handleStack(stack.name)}
+                />
+              ))}
+            </ButtonBox>
+            <GitHub>
+              <Title>* Git 주소</Title>
+              <GitInput
+                name="git"
+                placeholder="깃헙 링크 넣어주삼"
+                onChange={handleTextChange}
+              ></GitInput>
+            </GitHub>
+            <OpenCheckPortfolio>
+              <CheckBox>
+                <ChoiceBtn
+                  type="checkbox"
+                  id="choicebox"
+                  name="choiceBox"
+                  onChange={choicePortfolio}
+                ></ChoiceBtn>
+                <Label htmlFor="choicebox">내 포트폴리오 공개여부</Label>
+              </CheckBox>
+            </OpenCheckPortfolio>
+            <JoinBtn onClick={handleBtn}>apply</JoinBtn>
+          </ModalForm>
+        </Modal>
+      )}
+    </>
+  );
+};
+const GoToJoin = styled.button`
+  background-color: red;
+`;
+
+const ExitBtn = styled.button`
+  border: none;
+  background-color: transparent;
+  font-size: 20px;
+  position: absolute;
+  right: 7%;
+  top: 5%;
+`;
+
+const JoinBtn = styled.button`
+  width: 100%;
+  padding: 10px;
+  font-size: 15px;
+  border: 1px solid #ff9900;
+  border-radius: 10px;
+  color: #ff7425;
+  background-color: #fffefc;
+
+  :hover {
+    background-color: #ff9900;
+    border: 1px solid #ff9900;
+    color: #333;
+  }
+`;
+
+const OpenCheckPortfolio = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 40px;
+`;
+
+const Title = styled.p`
+  display: flex;
+  text-align: center;
+  width: 100%;
+  font-size: 15px;
+  font-weight: 700;
+  color: #666666;
+  margin-bottom: ${props => (props.noMargin ? 0 : '15px')};
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 40px;
+`;
+
+const GitHub = styled.div`
+  font-size: 15px;
+`;
+
+const GitInput = styled.input`
+  width: 100%;
+  height: 30px;
+  margin-bottom: 40px;
+  border: none;
+  border-bottom: 1px solid #333;
+  background: transparent;
+  outline: none;
+  font-size: 16px;
+
+  &:focus::placeholder {
+    color: transparent;
+  }
+`;
+
+const CheckBoxWrap = styled.div`
+  display: flex;
+  justify-content: space-around;
+  flex-direction: row;
+  margin-bottom: 40px;
+  width: 100%;
+  color: #333;
+`;
+
+const ChoiceBtn = styled.input`
+  margin-right: 10px;
+`;
+
+const CheckBox = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const Label = styled.label`
+  color: #333;
+`;
+
+const PositionBtn = styled.input`
+  margin-right: 10px;
+`;
+
+const ProjectName = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border-bottom: 1px solid #666666;
+  margin-bottom: 40px;
+`;
+
+const ProjectNameText = styled.p`
+  margin-bottom: 20px;
+  font-size: 16px;
+  color: #666666;
+`;
+
+const ModalForm = styled.form`
+  position: relative;
+  margin: 0 auto;
+  text-align: center;
+  padding: 50px;
+  width: 600px;
+  border: 1px solid #ff9900;
+  border-radius: 10px;
+  background-color: white;
+`;
+
+const Modal = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: #00000070;
+`;
+
+export default JoinModal;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 프로젝트 지원하기 위한 모달창 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 프로젝트 지원창
- 사용자가 프로젝트에 대한 정보를 볼수 있게 서버에서 `프로젝트명, 남은 인원, 필수 스택`정보를 받을 수 있게 구현
- 지원자의 포지션을 `체크박스 radio` 구현 (하나만 선택 가능)
- 지원자의 기술 스택 선택 (버튼을 컴포넌트화 하여 재사용)
- `git주소` 입력창은 `input 'text'` 구현
- 내 포트폴리오 공개여부는 선택사항으로 체크박스 구현
- 내 포트폴리오 공개여부 체크박스를 제외한 필수값 입력 시 `apply` 버튼 활성화 
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
<br />

## :: 기타 질문 및 특이 사항

