### PR TITLE
Add:fetch 상위컴포넌트로 옮김

### DIFF
--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Slider from 'react-slick/lib/slider';
 import styled from 'styled-components';
 import ProjectCarousel from './ProjectCarousel';
@@ -6,7 +6,11 @@ import { MAIN_CAROUSEL } from './carouselData';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
+const LIMIT = 12;
 const Main = () => {
+  const [deadline, setDeadline] = useState([]);
+  const [newProject, setNewProject] = useState([]);
+
   const option = {
     dots: true,
     infinite: true,
@@ -18,6 +22,19 @@ const Main = () => {
     nextArrow: <NextArrow isTop />,
     prevArrow: <PrevArrow isTop />,
   };
+
+  useEffect(() => {
+    fetch(
+      `http://10.58.3.182:8000/projects?sort=recent_created&limit=${LIMIT}&offset=0`
+    )
+      .then(res => res.json())
+      .then(data => setNewProject(data.results));
+    fetch(
+      `http://10.58.3.182:8000/projects?sort=deadline&limit=${LIMIT}&offset=0`
+    )
+      .then(res => res.json())
+      .then(data => setDeadline(data.results));
+  }, []);
 
   return (
     <MainWrap>
@@ -35,7 +52,7 @@ const Main = () => {
       >
         <BannerImg src="/images/wecodebanner.png" alt="wecodebanner" />
       </Banner>
-      <ProjectCarousel />
+      <ProjectCarousel deadline={deadline} newProject={newProject} />
     </MainWrap>
   );
 };

--- a/src/pages/Main/ProjectCarousel.js
+++ b/src/pages/Main/ProjectCarousel.js
@@ -1,40 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Slider from 'react-slick/lib/slider';
 import styled from 'styled-components';
 import Card from '../../components/Card/Card';
 
-const LIMIT = 12;
-const ProjectCarousel = () => {
-  const [deadline, setDeadline] = useState([]);
-  const [recommendation, setRecommendation] = useState([]);
-  const [newProject, setNewProject] = useState([]);
-
-  useEffect(() => {
-    fetch(
-      `http://10.58.3.182:8000/projects?sort=recent_created&limit=${LIMIT}&offset=0`
-    )
-      .then(res => res.json())
-      .then(data => setNewProject(data.results));
-  }, []);
-
-  useEffect(() => {
-    fetch(
-      `http://10.58.3.182:8000/projects?sort=deadline&limit=${LIMIT}&offset=0`
-    )
-      .then(res => res.json())
-      .then(data => setDeadline(data.results));
-  }, []);
-
-  useEffect(() => {
-    fetch(
-      `http://10.58.3.182:8000/projects?sort=recent_created&limit=${LIMIT}&offset=0`
-    )
-      .then(res => res.json())
-      .then(data => {
-        setRecommendation(data.results);
-      });
-  }, []);
-
+const ProjectCarousel = ({ newProject, deadline }) => {
   const option = {
     dots: false,
     infinite: true,
@@ -87,15 +56,6 @@ const ProjectCarousel = () => {
       <ProjectCarouselWrap>
         <Slider {...option}>
           {deadline.map(data => (
-            <Card key={data.project_id} data={data} />
-          ))}
-        </Slider>
-      </ProjectCarouselWrap>
-
-      <Title>💟 전체기수 추천</Title>
-      <ProjectCarouselWrap>
-        <Slider {...option}>
-          {recommendation.map(data => (
             <Card key={data.project_id} data={data} />
           ))}
         </Slider>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />
## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 컴포넌트 재사용화 설정을 위해 fetch 함수를 상위폴더로 옮김

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 컴포넌트를 재사용하기 위해 fetch 함수를 상위폴더로 옮김
 state는 상위폴더로 선언해주고, ProjectCarousel 컴포넌트에 porp으로 내려줘 state 값도 가질수 있도록 연결
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.
- 서버와 통신하는 함수로는 상위폴더에 다 올려주는 것이 맞고, 컴포넌트는 재사용하기 위함이 크기 때문에 fetch함수는 넣지 않는것이 좋음

<br />

## :: 기타 질문 및 특이 사항

